### PR TITLE
Change `repo` field in package.json to `repository`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "description": "Ionic Keyboard Plugin",
-  "repo": "https://github.com/driftyco/ionic-plugins-keyboard.git",
+  "repository": "https://github.com/driftyco/ionic-plugins-keyboard.git",
   "issue": "https://github.com/driftyco/ionic-plugins-keyboard/issues",
   "keywords": [
     "ionic",


### PR DESCRIPTION
The package.json includes a `repository` field to point to the source repository.

This patch changes `package.json` to use the `repository` field instead of `repo`.