### PR TITLE
Detect keyboard height change on iOS; Calculate Android screen height properly

### DIFF
--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -16,6 +16,11 @@ import android.view.View;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.inputmethod.InputMethodManager;
 
+// import additionally required classes for calculating screen height
+import android.view.Display;
+import android.graphics.Point;
+import android.os.Build;
+
 public class IonicKeyboard extends CordovaPlugin {
 
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -67,23 +72,54 @@ public class IonicKeyboard extends CordovaPlugin {
                             Rect r = new Rect();
                             //r will be populated with the coordinates of your view that area still visible.
                             rootView.getWindowVisibleDisplayFrame(r);
-                            
+
+                            // get status bar height in pixels
+                            Rect rectgle= new Rect();
+                            rootView.getWindowVisibleDisplayFrame(rectgle);
+                            int pixelStatusBarHeight = (int)(rectgle.top / density);
+
                             PluginResult result;
 
-                            int heightDiff = rootView.getRootView().getHeight() - r.bottom;
+                            // cache properties for later use
+                            int rootViewHeight = rootView.getRootView().getHeight();
+                            int resultBottom = r.bottom;
+                            int resultTop = r.top;
+
+                            // calculate screen height differently for android versions >= 21: Lollipop 5.x, Marshmallow 6.x
+                            //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5
+                            int screenHeight;
+
+                            if (Build.VERSION.SDK_INT >= 21) {
+                                Display display = cordova.getActivity().getWindowManager().getDefaultDisplay();
+                                Point size = new Point();
+                                display.getSize(size);
+                                screenHeight = size.y;
+                            } else {
+                                screenHeight = rootViewHeight;
+                            }
+
+                            //int heightDiff = rootView.getRootView().getHeight() - r.bottom;
+                            int heightDiff = screenHeight - resultBottom;
                             int pixelHeightDiff = (int)(heightDiff / density);
+
+
+
+
                             if (pixelHeightDiff > 100 && pixelHeightDiff != previousHeightDiff) { // if more than 100 pixels, its probably a keyboard...
-                            	String msg = "S" + Integer.toString(pixelHeightDiff);
+                                // String msg = "S" + Integer.toString(pixelHeightDiff);
+                                // return status bar height in addition to keyboard height
+                                String msg = "S" + Integer.toString(pixelHeightDiff) + ";" + Integer.toString(pixelStatusBarHeight);
                                 result = new PluginResult(PluginResult.Status.OK, msg);
                                 result.setKeepCallback(true);
                                 callbackContext.sendPluginResult(result);
                             }
                             else if ( pixelHeightDiff != previousHeightDiff && ( previousHeightDiff - pixelHeightDiff ) > 100 ){
-                            	String msg = "H";
+                                String msg = "H";
                                 result = new PluginResult(PluginResult.Status.OK, msg);
                                 result.setKeepCallback(true);
                                 callbackContext.sendPluginResult(result);
                             }
+
                             previousHeightDiff = pixelHeightDiff;
                          }
                     };

--- a/src/ios/IonicKeyboard.h
+++ b/src/ios/IonicKeyboard.h
@@ -2,7 +2,7 @@
 
 @interface IonicKeyboard : CDVPlugin <UIScrollViewDelegate> {
     @protected
-    id _keyboardShowObserver, _keyboardHideObserver;
+    id _keyboardShowObserver, _keyboardHideObserver, _keyboardChangeObserver;
 }
 
 // @property (readwrite, assign) BOOL hideKeyboardAccessoryBar;

--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -41,6 +41,20 @@
                                    //deprecated
                                    [weakSelf.commandDelegate evalJs:@"cordova.fireWindowEvent('native.hidekeyboard'); "];
                                }];
+
+    _keyboardChangeObserver = [nc addObserverForName:UIKeyboardWillChangeFrameNotification
+                                 object:nil
+                                 queue:[NSOperationQueue mainQueue]
+                                 usingBlock:^(NSNotification* notification) {
+
+                                     CGRect keyboardFrame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+                                     keyboardFrame = [self.viewController.view convertRect:keyboardFrame fromView:nil];
+
+                                     [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.keyboardchange', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
+
+                                     //deprecated
+                                     //[weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
+                                 }];
 }
 - (BOOL)disableScroll {
     return _disableScroll;

--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -38,12 +38,15 @@ channel.onCordovaReady.subscribe(function() {
     function success(msg) {
         var action = msg.charAt(0);
         if ( action === 'S' ) {
-            var keyboardHeight = msg.substr(1);
+            var heights = msg.substr(1).split(";");
+            var keyboardHeight = heights[0];
+            var statusBarHeight = heights[1];
             cordova.plugins.Keyboard.isVisible = true;
-            cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': + keyboardHeight });
+            // add statusBarHeight property to event object
+            cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': + keyboardHeight, 'statusBarHeight': + statusBarHeight });
 
             //deprecated
-            cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': + keyboardHeight });
+            cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': + keyboardHeight, 'statusBarHeight': + statusBarHeight });
         } else if ( action === 'H' ) {
             cordova.plugins.Keyboard.isVisible = false;
             cordova.fireWindowEvent('native.keyboardhide');


### PR DESCRIPTION
1) Add _keyboardChangeObserver for iOS to detect keyboard size change when switching to or from iOS emoji keyboard as the emoji keyboard's height is different from the "normal" keyboard. This fires a new event: "native:keyboardchange" in addition to the already existing events "native:keyboardshow" and "native:keyboardhide".

2) calculate screen height properly for android versions >= 21: Lollipop 5.x, Marshmallow 6.x.
See: http://stackoverflow.com/a/29257533/3642890 beware of nexus 5

Without having it verified, this pull request probably solves #192, #160 (1) and #193 (2), as well as #195.