### PR TITLE
Fix Android screen height calculation

### DIFF
--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -78,7 +78,6 @@ public class IonicKeyboard extends CordovaPlugin {
                             // cache properties for later use
                             int rootViewHeight = rootView.getRootView().getHeight();
                             int resultBottom = r.bottom;
-                            int resultTop = r.top;
 
                             // calculate screen height differently for android versions >= 21: Lollipop 5.x, Marshmallow 6.x
                             //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5

--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -73,11 +73,6 @@ public class IonicKeyboard extends CordovaPlugin {
                             //r will be populated with the coordinates of your view that area still visible.
                             rootView.getWindowVisibleDisplayFrame(r);
 
-                            // get status bar height in pixels
-                            Rect rectgle= new Rect();
-                            rootView.getWindowVisibleDisplayFrame(rectgle);
-                            int pixelStatusBarHeight = (int)(rectgle.top / density);
-                            
                             PluginResult result;
 
                             // cache properties for later use
@@ -102,8 +97,7 @@ public class IonicKeyboard extends CordovaPlugin {
 
                             int pixelHeightDiff = (int)(heightDiff / density);
                             if (pixelHeightDiff > 100 && pixelHeightDiff != previousHeightDiff) { // if more than 100 pixels, its probably a keyboard...
-                                // return status bar height in addition to keyboard height
-                                String msg = "S" + Integer.toString(pixelHeightDiff) + ";" + Integer.toString(pixelStatusBarHeight);
+                                String msg = "S" + Integer.toString(pixelHeightDiff);
                                 result = new PluginResult(PluginResult.Status.OK, msg);
                                 result.setKeepCallback(true);
                                 callbackContext.sendPluginResult(result);
@@ -119,8 +113,8 @@ public class IonicKeyboard extends CordovaPlugin {
                     };
 
                     rootView.getViewTreeObserver().addOnGlobalLayoutListener(list);
-                	
-                	
+
+
                     PluginResult dataResult = new PluginResult(PluginResult.Status.OK);
                     dataResult.setKeepCallback(true);
                     callbackContext.sendPluginResult(dataResult);

--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -16,6 +16,11 @@ import android.view.View;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.inputmethod.InputMethodManager;
 
+// import additionally required classes for calculating screen height
+import android.view.Display;
+import android.graphics.Point;
+import android.os.Build;
+
 public class IonicKeyboard extends CordovaPlugin {
 
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -67,13 +72,38 @@ public class IonicKeyboard extends CordovaPlugin {
                             Rect r = new Rect();
                             //r will be populated with the coordinates of your view that area still visible.
                             rootView.getWindowVisibleDisplayFrame(r);
+
+                            // get status bar height in pixels
+                            Rect rectgle= new Rect();
+                            rootView.getWindowVisibleDisplayFrame(rectgle);
+                            int pixelStatusBarHeight = (int)(rectgle.top / density);
                             
                             PluginResult result;
 
-                            int heightDiff = rootView.getRootView().getHeight() - r.bottom;
+                            // cache properties for later use
+                            int rootViewHeight = rootView.getRootView().getHeight();
+                            int resultBottom = r.bottom;
+                            int resultTop = r.top;
+
+                            // calculate screen height differently for android versions >= 21: Lollipop 5.x, Marshmallow 6.x
+                            //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5
+                            int screenHeight;
+
+                            if (Build.VERSION.SDK_INT >= 21) {
+                                Display display = cordova.getActivity().getWindowManager().getDefaultDisplay();
+                                Point size = new Point();
+                                display.getSize(size);
+                                screenHeight = size.y;
+                            } else {
+                                screenHeight = rootViewHeight;
+                            }
+
+                            int heightDiff = screenHeight - resultBottom;
+
                             int pixelHeightDiff = (int)(heightDiff / density);
                             if (pixelHeightDiff > 100 && pixelHeightDiff != previousHeightDiff) { // if more than 100 pixels, its probably a keyboard...
-                            	String msg = "S" + Integer.toString(pixelHeightDiff);
+                                // return status bar height in addition to keyboard height
+                                String msg = "S" + Integer.toString(pixelHeightDiff) + ";" + Integer.toString(pixelStatusBarHeight);
                                 result = new PluginResult(PluginResult.Status.OK, msg);
                                 result.setKeepCallback(true);
                                 callbackContext.sendPluginResult(result);

--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -12,7 +12,7 @@ Keyboard.hideKeyboardAccessoryBar = function(hide) {
     exec(null, null, "Keyboard", "hideKeyboardAccessoryBar", [hide]);
 };
 
-Keyboard.close = function() {	
+Keyboard.close = function() {
     exec(null, null, "Keyboard", "close", []);
 };
 
@@ -38,22 +38,12 @@ channel.onCordovaReady.subscribe(function() {
     function success(msg) {
         var action = msg.charAt(0);
         if ( action === 'S' ) {
-            var heights = msg.substr(1).split(";");
-            var keyboardHeight = heights[0];
-            var statusBarHeight = heights[1];
+            var keyboardHeight = msg.substr(1);
             cordova.plugins.Keyboard.isVisible = true;
-
-            // add statusBarHeight property to event object
-            cordova.fireWindowEvent('native.keyboardshow', {
-                'keyboardHeight': + keyboardHeight,
-                'statusBarHeight': + statusBarHeight
-            });
+            cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': + keyboardHeight });
 
             //deprecated
-            cordova.fireWindowEvent('native.showkeyboard', {
-                'keyboardHeight': + keyboardHeight,
-                'statusBarHeight': + statusBarHeight
-            });
+            cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': + keyboardHeight });
         } else if ( action === 'H' ) {
             cordova.plugins.Keyboard.isVisible = false;
             cordova.fireWindowEvent('native.keyboardhide');

--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -38,12 +38,22 @@ channel.onCordovaReady.subscribe(function() {
     function success(msg) {
         var action = msg.charAt(0);
         if ( action === 'S' ) {
-            var keyboardHeight = msg.substr(1);
+            var heights = msg.substr(1).split(";");
+            var keyboardHeight = heights[0];
+            var statusBarHeight = heights[1];
             cordova.plugins.Keyboard.isVisible = true;
-            cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': + keyboardHeight });
+
+            // add statusBarHeight property to event object
+            cordova.fireWindowEvent('native.keyboardshow', {
+                'keyboardHeight': + keyboardHeight,
+                'statusBarHeight': + statusBarHeight
+            });
 
             //deprecated
-            cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': + keyboardHeight });
+            cordova.fireWindowEvent('native.showkeyboard', {
+                'keyboardHeight': + keyboardHeight,
+                'statusBarHeight': + statusBarHeight
+            });
         } else if ( action === 'H' ) {
             cordova.plugins.Keyboard.isVisible = false;
             cordova.fireWindowEvent('native.keyboardhide');


### PR DESCRIPTION
This calculates the screen height differently for android versions >= 21: Lollipop 5.x, Marshmallow 6.x. See http://stackoverflow.com/a/29257533/3642890 beware of nexus 5