### PR TITLE
iOS: Introduce new native.keyboardchange event to detect keyboard height change (emoji keyboard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,25 @@ Supported Platforms
 -------------------
 
 - iOS, Android, Blackberry 10, Windows
+
+
+native.keyboardchange
+=================
+
+This event fires when the keyboard will be resized. When will this ever occur? The iOS emoji keyboard height is different from the standard keyboards, but only if the device keyboard "Preditive" setting is turned off. When switching the keyboard from or to the emoji keyboard, the keyboardchange event fires and the keyboard height is recalculated.
+
+    window.addEventListener('native.keyboardchange', keyboardChangeHandler);
+
+    function keyboardChangeHandler(e){
+        alert('Keyboard resized, new keyboard height is ' + e.keyboardHeight);
+    }
+
+Properties
+-----------
+
+None
+
+Supported Platforms
+-------------------
+
+- iOS

--- a/src/ios/IonicKeyboard.h
+++ b/src/ios/IonicKeyboard.h
@@ -3,7 +3,7 @@
 
 @interface IonicKeyboard : CDVPlugin <UIScrollViewDelegate> {
     @protected
-    id _keyboardShowObserver, _keyboardHideObserver;
+    id _keyboardShowObserver, _keyboardHideObserver, _keyboardChangeObserver;
     IMP wkOriginalImp, uiOriginalImp, nilImp;
     Method wkMethod, uiMethod;
 }

--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -50,6 +50,20 @@
                                    //deprecated
                                    [weakSelf.commandDelegate evalJs:@"cordova.fireWindowEvent('native.hidekeyboard'); "];
                                }];
+
+    _keyboardChangeObserver = [nc addObserverForName:UIKeyboardWillChangeFrameNotification
+                               object:nil
+                               queue:[NSOperationQueue mainQueue]
+                               usingBlock:^(NSNotification* notification) {
+
+                                  CGRect keyboardFrame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+                                  keyboardFrame = [self.viewController.view convertRect:keyboardFrame fromView:nil];
+
+                                  [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.keyboardchange', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
+
+                                  //deprecated
+                                  [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.changekeyboard', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
+                               }];
 }
 
 - (BOOL)disableScroll {


### PR DESCRIPTION
Introduce an additional keyboardchange event in order to detect keyboard height change on iOS. Keyboard height changes when switching to or from the iOS emoji keyboard with device keyboard setting "Predictive" turned off.