### PR TITLE
Fix issue #173

### DIFF
--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -37,8 +37,6 @@
 
                                    [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.plugins.Keyboard.isVisible = true; cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
 
-                                   //deprecated
-                                   [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
                                }];
 
     _keyboardHideObserver = [nc addObserverForName:UIKeyboardWillHideNotification
@@ -46,9 +44,6 @@
                                queue:[NSOperationQueue mainQueue]
                                usingBlock:^(NSNotification* notification) {
                                    [weakSelf.commandDelegate evalJs:@"cordova.plugins.Keyboard.isVisible = false; cordova.fireWindowEvent('native.keyboardhide'); "];
-
-                                   //deprecated
-                                   [weakSelf.commandDelegate evalJs:@"cordova.fireWindowEvent('native.hidekeyboard'); "];
                                }];
 }
 

--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -41,15 +41,9 @@ channel.onCordovaReady.subscribe(function() {
             var keyboardHeight = msg.substr(1);
             cordova.plugins.Keyboard.isVisible = true;
             cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': + keyboardHeight });
-
-            //deprecated
-            cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': + keyboardHeight });
         } else if ( action === 'H' ) {
             cordova.plugins.Keyboard.isVisible = false;
             cordova.fireWindowEvent('native.keyboardhide');
-
-            //deprecated
-            cordova.fireWindowEvent('native.hidekeyboard');
         }
     }
 });


### PR DESCRIPTION
- delete call of events deprecated bug in iOS see #173;
- delete events 'deprecated' platform android compatibility Android