### PR TITLE
Windows issue - hideKeyboardAccessoryBar has to be implemented in Proxy

### DIFF
--- a/src/windows/KeyboardProxy.js
+++ b/src/windows/KeyboardProxy.js
@@ -18,6 +18,9 @@ inputPane.addEventListener('showing', function(e) {
     cordova.plugins.Keyboard.isVisible = true;
 });
 
+module.exports.hideKeyboardAccessoryBar = function (hide) {
+};
+
 module.exports.disableScroll = function (disable) {
     keyboardScrollDisabled = disable;
 };


### PR DESCRIPTION
Missing export causes breakpoint when debugging on Windows, because of undefined method 