### PR TITLE
CFBundleAllowMixedLocalizations true

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,9 @@
                 <param name="ios-package" value="IonicKeyboard" onload="true" />
             </feature>
         </config-file>
+        <config-file target="*-Info.plist" parent="CFBundleAllowMixedLocalizations">
+            <true/>
+        </config-file>
         <header-file src="src/ios/IonicKeyboard.h" />
         <source-file src="src/ios/IonicKeyboard.m" />
     </platform>


### PR DESCRIPTION
As described in #162 I have tried to fix the issue missing translations. All buttons in the accessory bar and for example the date control are English although the phone is set to another language.

Should this be solved with these options in the plugin. For now I am setting this entry via hooks. Or is this dangerous to set this in general with this plugin?