### PR TITLE
Fix event.keyboardHeight value for iPad hardware keyboard bar

### DIFF
--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -32,13 +32,15 @@
                                queue:[NSOperationQueue mainQueue]
                                usingBlock:^(NSNotification* notification) {
 
-                                   CGRect keyboardFrame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
-                                   keyboardFrame = [self.viewController.view convertRect:keyboardFrame fromView:nil];
+                                   CGRect screen = [[UIScreen mainScreen] bounds];
+                                   CGRect keyboard = ((NSValue*)notification.userInfo[@"UIKeyboardFrameEndUserInfoKey"]).CGRectValue;
+                                   CGRect intersection = CGRectIntersection(screen, keyboard);
+                                   CGFloat height = MIN(intersection.size.width, intersection.size.height);
 
-                                   [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.plugins.Keyboard.isVisible = true; cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
+                                   [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.plugins.Keyboard.isVisible = true; cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': %f }); ", height]];
 
                                    //deprecated
-                                   [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
+                                   [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': %f }); ", height]];
                                }];
 
     _keyboardHideObserver = [nc addObserverForName:UIKeyboardWillHideNotification


### PR DESCRIPTION
Disclaimer: this is the first ever Objective-C I wrote in my life. In fact, I just byte-for-byte copied the code from [cordova-plugin-keyboard](https://github.com/cjpearson/cordova-plugin-keyboard/blob/44e3ef9371ee496d9496e7df6f43f89261ea90f8/src/ios/CDVKeyboard.m#L98-L102).

When connecting a hardware keyboard, iPads hide the full software keyboard but still show a reduced bar with undo / redo / paste, etc.:

![bar](https://cloud.githubusercontent.com/assets/166943/25857846/41af9a2c-34a8-11e7-9370-f0734c8ff021.png)

This can be tested by hitting **Cmd + Shift + K** or **Hardware > Keyboard > Connect Hardware Keyboard** in the iOS Simulator.

Before the fix, the `keyboardHeight` value of the `native.keyboardshow` event with hardware keyboard connected was 313, exact same as full software keyboard. For instance, this caused [our app](https://missiveapp.com/) to apply a wrong margin-bottom, as shown here (light grey area):

![before](https://cloud.githubusercontent.com/assets/166943/25858411/adf1c29a-34a9-11e7-8228-49e2357db322.png)

After the fix, `keyboardHeight` now returns 55, which is the actual height of the hardware keyboard bar alone:

![after](https://cloud.githubusercontent.com/assets/166943/25858511/ec8dfd70-34a9-11e7-97c1-b1f9c95c0dc8.png)

Tested with the following devices on iOS Simulator, in both portrait and landscape:

- iPad Pro 9.7 inch - iOS 10.3
- iPad Pro 12.9 inch - iOS 10.3
- iPad Air 2 - iOS 9.3
- iPhone 7 Plus - iOS 10.3
- iPhone 5S - iOS 9.3